### PR TITLE
merge gesh's new patch & change pkgname

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,25 +1,28 @@
 # Maintainer: Fernando Ayats <ayatsfer[at]gmail[dot]com>
 groups=('modified')
 pkgname=qemu-android-x86
-_pkgver="7.1-r5"
-pkgver=7.1_r5
-pkgrel=1
+_pkgver="9.0-r2"
+pkgver=9.0.r2
+pkgrel=3
 pkgdesc="Android-x86 environment via QEMU and VirGL"
 arch=("x86_64")
 url="http://www.android-x86.org/"
 license=('Apache' 'GPL2' 'custom:Creative Commons 3.0 Attribution Unported')
-depends=('rxvt-unicode' 'zenity' 'qemu' 'hicolor-icon-theme') 
-makedepends=('inkscape' 'squashfs-tools')
+depends=('qemu' 'hicolor-icon-theme')
+makedepends=('squashfs-tools')
+optdepends=(
+    'rxvt-unicode: for GUI support'
+    'zenity: for GUI support')
 install="qemu-android-x86.install"
-source=("android-x86-${_pkgver}.${arch}.rpm::https://osdn.mirror.constant.com//android-x86/67834/android-x86-7.1-r5.x86_64.rpm"
+source=("android-x86-${_pkgver}.${arch}.rpm::https://osdn.net/frs/redir.php?m=constant&f=android-x86%2F71931%2Fandroid-x86-${_pkgver}.${arch}.rpm"
 		"https://upload.wikimedia.org/wikipedia/commons/d/d7/Android_robot.svg"
 		"qemu-android"
 		"config"
 		"qemu-android.desktop")
-sha256sums=('31efd1a4fa9549a91cacb7bdcb256a057158aa57aec632e41922664cedc7cd39'
+sha256sums=('6e54e25d945e050cf6a6ad2ac3e0775add04b1d586989e29276499c8d11e629f'
             '8c80b881727efc8831c8ef53806e7c1d0427607e145aae09061c4870b6cd402f'
-            'facf856b31133d2eb4632ec068864f5611d676d9563209fc14ea76aa77f1cec1'
-            'eb9911aaa613bb08041e413dfad6481cc0e812caf6051c3e86e426fe76549596'
+            '455ed7ef3db79aa183d3f99219892c42f949d64be62a81236c6269ff6076c9f0'
+            '814171660aaee37c417cb9cedfe47b756f8bce59ce0940a304935d4f748995d1'
             '8a5ed6a6c1a4dfd1c8af0ff5de48965ec2dc6b50f87e5f990d33c7025f63c8ec')
 
 #PKGEXT=".pkg.tar"
@@ -34,17 +37,12 @@ build() {
 
 package() {
 
-	mkdir -p $pkgdir/usr/share/android-x86 $pkgdir/usr/bin $pkgdir/usr/share/applications
-	install -m0644 $srcdir/android-${_pkgver}/* $pkgdir/usr/share/android-x86
-	install -m0644 $srcdir/usr/bin/qemu-android $pkgdir/usr/share/android-x86/original.qemu-android
-	install -m0644 $srcdir/config $pkgdir/usr/share/android-x86
-	install -m0644 $srcdir/qemu-android.desktop $pkgdir/usr/share/applications
-	install -m0755 $srcdir/qemu-android $pkgdir/usr/bin/qemu-android
+    install -Dm0644 "$srcdir/config" "$srcdir/android-${_pkgver}"/* -t "$pkgdir/usr/share/android-x86"
+    install -Dm0644 "$srcdir/usr/bin/qemu-android" "$pkgdir/usr/share/android-x86/original.qemu-android"
+    install -Dm0644 "$srcdir/qemu-android.desktop" "$pkgdir/usr/share/applications/qemu-android.desktop"
+    install -Dm0755 "$srcdir/qemu-android" "$pkgdir/usr/bin/qemu-android"
 
-	iconsizes=(16 32 64 128 256 512)
-	for size in "${iconsizes[@]}"; do
-		mkdir -p $pkgdir/usr/share/icons/hicolor/${size}x${size}/apps
-		inkscape -o $pkgdir/usr/share/icons/hicolor/${size}x${size}/apps/qemu-android.png -w $size -h $size $srcdir/Android_robot.svg
-	done
+    install -Dm0644 "$srcdir/Android_robot.svg" \
+        "$pkgdir/usr/share/icons/hicolor/scalable/apps/qemu-android.svg"
 
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,7 +13,7 @@ makedepends=('squashfs-tools')
 optdepends=(
     'rxvt-unicode: for GUI support'
     'zenity: for GUI support')
-conflicts=('qemu-android-x86')
+provides=('qemu-android-x86')
 install="qemu-android-x86.install"
 source=("android-x86-${_pkgver}.${arch}.rpm::https://osdn.net/frs/redir.php?m=constant&f=android-x86%2F71931%2Fandroid-x86-${_pkgver}.${arch}.rpm"
 		"https://upload.wikimedia.org/wikipedia/commons/d/d7/Android_robot.svg"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -19,7 +19,7 @@ source=("android-x86-${_pkgver}.${arch}.rpm::https://osdn.net/frs/redir.php?m=co
 		"qemu-android.desktop")
 sha256sums=('6e54e25d945e050cf6a6ad2ac3e0775add04b1d586989e29276499c8d11e629f'
             '8c80b881727efc8831c8ef53806e7c1d0427607e145aae09061c4870b6cd402f'
-            '9d856c33ed81529b2a07230e8a2e9586d4fa515eea713941259f6ae46274065d'
+            'e000cae3acd841686e8765c32bc203e8764f556e8a2bb32892d437bf3cad11b3'
             'e9524cdb27c57e6650af763b2231d67ff3e2beb12f52133e7e95eda4f16b0881'
             '8a5ed6a6c1a4dfd1c8af0ff5de48965ec2dc6b50f87e5f990d33c7025f63c8ec')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,13 +2,15 @@
 pkgname=qemu-android-x86
 _pkgver="9.0-r2"
 pkgver=9.0.r2
-pkgrel=2
+pkgrel=3
 pkgdesc="Android-x86 environment via QEMU and VirGL"
 arch=("x86_64")
 url="http://www.android-x86.org/"
 license=('Apache' 'GPL2' 'custom:Creative Commons 3.0 Attribution Unported')
-depends=('rxvt-unicode' 'zenity' 'qemu' 'hicolor-icon-theme')
-makedepends=('inkscape')
+depends=('qemu' 'hicolor-icon-theme')
+optdepends=(
+    'rxvt-unicode: for GUI support'
+    'zenity: for GUI support')
 install="qemu-android-x86.install"
 source=("android-x86-${_pkgver}.${arch}.rpm::https://osdn.net/frs/redir.php?m=constant&f=android-x86%2F71931%2Fandroid-x86-${_pkgver}.${arch}.rpm"
 		"https://upload.wikimedia.org/wikipedia/commons/d/d7/Android_robot.svg"
@@ -21,21 +23,14 @@ sha256sums=('6e54e25d945e050cf6a6ad2ac3e0775add04b1d586989e29276499c8d11e629f'
             'e9524cdb27c57e6650af763b2231d67ff3e2beb12f52133e7e95eda4f16b0881'
             '8a5ed6a6c1a4dfd1c8af0ff5de48965ec2dc6b50f87e5f990d33c7025f63c8ec')
 
-#PKGEXT=".pkg.tar"
-
 package() {
 
-	mkdir -p $pkgdir/usr/share/android-x86 $pkgdir/usr/bin $pkgdir/usr/share/applications
-	install -m0644 $srcdir/android-${_pkgver}/* $pkgdir/usr/share/android-x86
-	install -m0644 $srcdir/usr/bin/qemu-android $pkgdir/usr/share/android-x86/original.qemu-android
-	install -m0644 $srcdir/config $pkgdir/usr/share/android-x86
-	install -m0644 $srcdir/qemu-android.desktop $pkgdir/usr/share/applications
-	install -m0755 $srcdir/qemu-android $pkgdir/usr/bin/qemu-android
+    install -Dm0644 "$srcdir/config" "$srcdir/android-${_pkgver}"/* -t "$pkgdir/usr/share/android-x86"
+    install -Dm0644 "$srcdir/usr/bin/qemu-android" "$pkgdir/usr/share/android-x86/original.qemu-android"
+    install -Dm0644 "$srcdir/qemu-android.desktop" "$pkgdir/usr/share/applications/qemu-android.desktop"
+    install -Dm0755 "$srcdir/qemu-android" "$pkgdir/usr/bin/qemu-android"
 
-	iconsizes=(16 32 64 128 256 512)
-	for size in "${iconsizes[@]}"; do
-		mkdir -p $pkgdir/usr/share/icons/hicolor/${size}x${size}/apps
-		inkscape -o $pkgdir/usr/share/icons/hicolor/${size}x${size}/apps/qemu-android.png -w $size -h $size $srcdir/Android_robot.svg
-	done
+    install -Dm0644 "$srcdir/Android_robot.svg" \
+        "$pkgdir/usr/share/icons/hicolor/scalable/apps/qemu-android.svg"
 
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -19,7 +19,7 @@ source=("android-x86-${_pkgver}.${arch}.rpm::https://osdn.net/frs/redir.php?m=co
 		"qemu-android.desktop")
 sha256sums=('6e54e25d945e050cf6a6ad2ac3e0775add04b1d586989e29276499c8d11e629f'
             '8c80b881727efc8831c8ef53806e7c1d0427607e145aae09061c4870b6cd402f'
-            'e53911e378a6048d88d4fbaeb870c58f57c44142450527ee99b3c12baa15099a'
+            '9d856c33ed81529b2a07230e8a2e9586d4fa515eea713941259f6ae46274065d'
             'e9524cdb27c57e6650af763b2231d67ff3e2beb12f52133e7e95eda4f16b0881'
             '8a5ed6a6c1a4dfd1c8af0ff5de48965ec2dc6b50f87e5f990d33c7025f63c8ec')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,9 +1,9 @@
 # Maintainer: Fernando Ayats <ayatsfer[at]gmail[dot]com>
 groups=('modified')
-pkgname=qemu-android-x86
-_pkgver="9.0-r2"
-pkgver=9.0.r2
-pkgrel=3
+pkgname=qemu-android-x86-nougat
+_pkgver="7.1-r5"
+pkgver=7.1.r5
+pkgrel=0
 pkgdesc="Android-x86 environment via QEMU and VirGL"
 arch=("x86_64")
 url="http://www.android-x86.org/"
@@ -13,13 +13,14 @@ makedepends=('squashfs-tools')
 optdepends=(
     'rxvt-unicode: for GUI support'
     'zenity: for GUI support')
+conflicts=('qemu-android-x86')
 install="qemu-android-x86.install"
 source=("android-x86-${_pkgver}.${arch}.rpm::https://osdn.net/frs/redir.php?m=constant&f=android-x86%2F71931%2Fandroid-x86-${_pkgver}.${arch}.rpm"
 		"https://upload.wikimedia.org/wikipedia/commons/d/d7/Android_robot.svg"
 		"qemu-android"
 		"config"
 		"qemu-android.desktop")
-sha256sums=('6e54e25d945e050cf6a6ad2ac3e0775add04b1d586989e29276499c8d11e629f'
+sha256sums=('31efd1a4fa9549a91cacb7bdcb256a057158aa57aec632e41922664cedc7cd39'
             '8c80b881727efc8831c8ef53806e7c1d0427607e145aae09061c4870b6cd402f'
             '455ed7ef3db79aa183d3f99219892c42f949d64be62a81236c6269ff6076c9f0'
             '814171660aaee37c417cb9cedfe47b756f8bce59ce0940a304935d4f748995d1'

--- a/config
+++ b/config
@@ -26,8 +26,8 @@ VIDEO="1280x720x32"
 DATA="$HOME/.config/android-x86/data.img"
 
 # Data partition size in megabytes.  Only used on creation of a partition image.
-# defaults to 16384.
-#DATASIZE=16384
+# defaults to 2048.
+#DATASIZE=2048
 
 # System partition location
 # The default install location will be /usr/share/android-x86/system.img, which

--- a/qemu-android
+++ b/qemu-android
@@ -39,7 +39,6 @@ else
 fi
 
 # Set meaningful defaults
-IN_SUDO=0
 IN_TERMINAL=0
 RAM=${RAM:-2048}
 CORES=${CORES:-2}
@@ -73,8 +72,7 @@ if [ $DATA == "none" ]; then
 	DATA_CMDLINE=""
 elif [ -d $DATA ]; then
 	echo "9p mode selected."
-	IN_SUDO=1
-	DATA_QEMULINE="-virtfs local,id=data,path=${DATA},security_model=passthrough,mount_tag=data"
+   DATA_QEMULINE="-virtfs local,id=data,path=${DATA},security_model=mapped-xattr,mount_tag=data"
 	DATA_CMDLINE="DATA=9p"
 else
 	# sudo should only be needed for 9p, if KVM is set up right
@@ -135,7 +133,6 @@ do_qemu() {
 	DO_CMD=""
 
 	[ $IN_TERMINAL -eq 1 ] && [ $GUI -eq 1 ] && DO_CMD+="$URXVT -title Android-x86_Console -e "
-	[ $IN_SUDO -eq 1 ] && DO_CMD+="/usr/bin/sudo "
 	DO_CMD+=$QEMU
 
 

--- a/qemu-android
+++ b/qemu-android
@@ -30,19 +30,22 @@ nope() {
 	exit 1
 }
 
+SYSCONFIG=/usr/share/android-x86/config
+CONFIGDIR="${XDG_CONFIG_HOME:-$HOME/.config}"/android-x86
+CONFIG="$CONFIGDIR"/config
 
 # Check for config file, source
-if [ -e $HOME/.config/android-x86/config ]; then
-	. $HOME/.config/android-x86/config
+if [ -r "$CONFIG" ]; then
+   . "$CONFIG"
 else
-	nope "Copy /usr/share/android-x86/config to ${HOME}/.config/android-x86 and modify.  It explains things."
+   nope "Copy $SYSCONFIG to $CONFIGDIR and modify. It explains things."
 fi
 
 # Set meaningful defaults
 IN_TERMINAL=0
 RAM=${RAM:-2048}
 CORES=${CORES:-2}
-DATA=${DATA:-"${HOME}/.config/android-x86/data.img"}
+DATA=${DATA:-"$CONFIGDIR/data.img"}
 DATASIZE=${DATASIZE:-2048}
 CPU=${CPU:-"host"}
 NETPORT=${NETPORT:-47000}
@@ -56,9 +59,11 @@ INITRD=${INITRD:-"/usr/share/android-x86/initrd.img"}
 RAMDISK=${RAMDISK:-"/usr/share/android-x86/ramdisk.img"}
 KERNEL=${KERNEL:-"/usr/share/android-x86/kernel"}
 
-if [ ! -e $SYSTEMIMG ] || [ ! -e $INITRD ] || [ ! -e $RAMDISK ] || [ ! -e $KERNEL ]; then
-	nope "System images aren't installed.  Check your android-x86 package."
-fi
+for i in "$SYSTEMIMG" "$INITRD" "$RAMDISK" "$KERNEL"; do
+   if [ ! -e "$i" ]; then
+       nope "System image $i isn't installed.  Check your android-x86 package."
+   fi
+done
 
 #QEMU=qemu-system-${QEMU_ARCH}
 # Archlinux is x86_64 only

--- a/qemu-android
+++ b/qemu-android
@@ -31,21 +31,23 @@ nope() {
 	exit 1
 }
 
+SYSCONFIG=/usr/share/android-x86/config
+CONFIGDIR="${XDG_CONFIG_HOME:-$HOME/.config}"/android-x86
+CONFIG="$CONFIGDIR"/config
 
 # Check for config file, source
-if [ -e $HOME/.config/android-x86/config ]; then
-	. $HOME/.config/android-x86/config
+if [ -r "$CONFIG" ]; then
+   . "$CONFIG"
 else
-	nope "Copy /usr/share/android-x86/config to ${HOME}/.config/android-x86 and modify.  It explains things."
+   nope "Copy $SYSCONFIG to $CONFIGDIR and modify. It explains things."
 fi
 
 # Set meaningful defaults
-IN_SUDO=0
 IN_TERMINAL=0
 RAM=${RAM:-4096}
 CORES=${CORES:-2}
-DATA=${DATA:-"${HOME}/.config/android-x86/data.img"}
-DATASIZE=${DATASIZE:-16384}
+DATA=${DATA:-"$CONFIGDIR/data.img"}
+DATASIZE=${DATASIZE:-2048}
 CPU=${CPU:-"host"}
 NETPORT=${NETPORT:-47000}
 # TODO figure out why GTK doesn't work on all my machines.  Might obviate the need to URXVT for serial console
@@ -57,9 +59,11 @@ INITRD=${INITRD:-"/usr/share/android-x86/initrd.img"}
 RAMDISK=${RAMDISK:-"/usr/share/android-x86/ramdisk.img"}
 KERNEL=${KERNEL:-"/usr/share/android-x86/kernel"}
 
-if [ ! -e $INITRD ] || [ ! -e $RAMDISK ] || [ ! -e $KERNEL ]; then
-	nope "System images aren't installed.  Check your android-x86 package."
-fi
+for i in "$INITRD" "$RAMDISK" "$KERNEL"; do
+   if [ ! -e "$i" ]; then
+       nope "System image $i isn't installed.  Check your android-x86 package."
+   fi
+done
 
 #QEMU=qemu-system-${QEMU_ARCH}
 # Archlinux is x86_64 only
@@ -73,8 +77,7 @@ if [ $DATA == "none" ]; then
 	DATA_CMDLINE=""
 elif [ -d $DATA ]; then
 	echo "9p mode selected."
-	IN_SUDO=1
-	DATA_QEMULINE="-virtfs local,id=data,path=${DATA},security_model=passthrough,mount_tag=data"
+   DATA_QEMULINE="-virtfs local,id=data,path=${DATA},security_model=mapped-xattr,mount_tag=data"
 	DATA_CMDLINE="DATA=9p"
 else
 	# sudo should only be needed for 9p, if KVM is set up right
@@ -116,7 +119,7 @@ if [ ! -e $SYSTEMIMG ]; then
         cp "/usr/share/android-x86/system.img" $SYSTEMIMG
 	fi
 
-elif [ ! -w $SYSTEMIMG]; then
+elif [ ! -w $SYSTEMIMG ]; then
 	nope "System partition $SYSTEMIMG isn't writeable."
 fi
 
@@ -153,7 +156,6 @@ do_qemu() {
 	DO_CMD=""
 
 	[ $IN_TERMINAL -eq 1 ] && [ $GUI -eq 1 ] && DO_CMD+="$URXVT -title Android-x86_Console -e "
-	[ $IN_SUDO -eq 1 ] && DO_CMD+="/usr/bin/sudo "
 	DO_CMD+=$QEMU
 
 

--- a/qemu-android-x86.install
+++ b/qemu-android-x86.install
@@ -2,8 +2,8 @@ post_install() {
   gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
   update-desktop-database -q
   echo "To use, per user:"
-  echo "	mkdir ~/.config/android-x86 &&"
-  echo "		cp /usr/share/android-x86/config ~/.config/android-x86"
+  echo "$ mkdir ~/.config/android-x86 && \\"
+  echo "  cp /usr/share/android-x86/config ~/.config/android-x86"
   echo "And then edit the config file to taste."
 }
 

--- a/qemu-android-x86.install
+++ b/qemu-android-x86.install
@@ -2,8 +2,8 @@ post_install() {
   gtk-update-icon-cache -q -t -f usr/share/icons/hicolor
   update-desktop-database -q
   echo "To use, per user:"
-  echo "	mkdir ~/.config/android-x86 &&"
-  echo "		cp /usr/share/android-x86/config ~/.config/android-x86"
+  echo "$ mkdir ~/.config/android-x86 && \\"
+  echo "  cp /usr/share/android-x86/config \$XDG_CONFIG_HOME/android-x86"
   echo "And then edit the config file to taste."
 }
 


### PR DESCRIPTION
gesh commented on [2021-07-08 22:35](https://aur.archlinux.org/packages/qemu-android-x86/#comment-816492)

Android-x86 8.1 & 9.1 don't work for me. Maybe you either. To separated from 9.0, let's change the `pkgname` to `qemu-android-x86-nougat`